### PR TITLE
Add horizontal scroll to the sidebar

### DIFF
--- a/airflow_code_editor/static/css/gitweb.css
+++ b/airflow_code_editor/static/css/gitweb.css
@@ -57,10 +57,11 @@ body {
 #sidebar .branch-current {
   font-weight: bold;
 }
-#sidebar #sidebar-content {
+#sidebar-content {
   flex: 1 1 0;
   -webkit-flex: 1 1 0;
-  overflow-x: hidden;
+  height: 100%;
+  overflow-x: auto;
   overflow-y: auto;
   cursor: default;
   color: #eeeeee;


### PR DESCRIPTION
Hello.

I've installed 4.0.0 version with new file tree feature.

But I found that in case of long file names I cannot scroll them horizontally because there is no scroll bar:
![remmina_0001BDTRM02 (balabit2:14057)_balabit2 msk mts ru:14057_202159-161550](https://user-images.githubusercontent.com/4661021/117579491-b4b56a00-b0fb-11eb-8c91-a9d06a3897d7.png)

I've enabled it:
![remmina_0001BDTRM02 (balabit2:14057)_balabit2 msk mts ru:14057_202159-16161](https://user-images.githubusercontent.com/4661021/117579529-f219f780-b0fb-11eb-93db-90510b017c43.png)

