### PR TITLE
Fix empty files list

### DIFF
--- a/src/components/Files.vue
+++ b/src/components/Files.vue
@@ -451,9 +451,9 @@ export default {
             let path = null;
             let last = this.stack.last();
             if (self.isGit) { // git
-                path = self.normalize('tree/git/' + last.object);
+                path = 'tree' + self.normalize('git/' + last.object);
             } else { // local
-                path = self.normalize('tree/files' + (last.object || ''));
+                path = 'tree' + self.normalize('files' + (last.object || ''));
                 // Update url hash
                 document.location.hash = self.normalize('files' + (last.object || ''));
             }


### PR DESCRIPTION
Hi.

After upgrading extension to the latest version I've got an empty list of files:
![изображение](https://user-images.githubusercontent.com/4661021/144290883-f89a67a7-f54c-4974-b756-d826bbfed733.png)

But files list in the sidebar is showing without errors.

It is caused by wrong URL `http://mydomain/code_editor//tree/files` instead of `http://mydomain/code_editor/tree/files`.
This PR should fix the issue.
